### PR TITLE
Added configuration for Workload Identity federation in alert-menta.yaml

### DIFF
--- a/.github/workflows/alert-menta.yaml
+++ b/.github/workflows/alert-menta.yaml
@@ -12,9 +12,17 @@ jobs:
     permissions:
       issues: write
       contents: read
+      id-token: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/<PROVIDER_ID>/locations/global/workloadIdentityPools/<POOL_ID>/providers/<PROVIDER_NAME>'
+          service_account: '<SERVICE_ACCOUNT>@<PROJECT_ID>.iam.gserviceaccount.com'
 
       - name: Download and Install alert-menta
         run: |


### PR DESCRIPTION
## 概要	PRでの対応内容の概要
Google Cloud の Workload Identity 連携を利用するための設定を記述し，GitHub Actions から VertexAI を呼び出せるようにした

## やったこと	対応内容を簡潔にリストアップ
- alert-menta.yaml に Workload Identity 連携利用のためのステップを追加

## 変更結果	操作動画やスクショ、レスポンス内容など
特になし

## やらないこと	このPRでスコープ外とする内容
特になし

## 注意事項	マージした後はこのコマンドを実行してね、などメンバーに知らせるべき内容
特になし

## どうやるのか	変更後の使い方や再現（確認）手順
1. Google Cloud 側で Workload Identity Pool, Provider, Service Account の設定が必要（参考文献の手順を参照）
1. alert-menta.yaml の Workload Identity 連携の関連項目（<PROVIDER_ID>等）に Google Cloud 側で設定を行った内容を記載する
```yaml
- id: 'auth'
  name: 'Authenticate to Google Cloud'
  uses: 'google-github-actions/auth@v1'
  with:
    workload_identity_provider: 'projects/<PROVIDER_ID>/locations/global/workloadIdentityPools/<POOL_ID>/providers/<PROVIDER_NAME>'
    service_account: '<SERVICE_ACCOUNT>@<PROJECT_ID>.iam.gserviceaccount.com'
```

## 課題	悩んでいるところ、とくにレビューしてほしいところ（これは直接ソースにコメントしてもいいと思います。）
- ServiceAccount のクレデンシャル json ファイルと Workload Identity 連携のどちらが優先されるのかは未検証

## 備考	その他追記事項、関連資料や参考資料などをまとめる
- [GitHub ActionsでWorkload Identityでの認証を入れてGoogle CloudのAPIを叩く](https://zenn.dev/satohjohn/articles/1645be8e83eab6)
