### PR TITLE
[Feature]: User-defined custom commands can now be executed.

### DIFF
--- a/.alert-menta.user.yaml
+++ b/.alert-menta.user.yaml
@@ -10,15 +10,18 @@ ai:
   vertexai:
     project: "<YOUR_PROJECT_ID>"
     location: "us-central1"
-    model: "gemini-1.5-flash-001"
+    model: "gemini-2.0-flash-001"
   
   commands:
     - describe:
         description: "Generate a detailed description of the Issue."
         system_prompt: "The following is the GitHub Issue and comments on it. Please Generate a detailed description.\n"
+        require_intent: false
     - suggest:
         description: "Provide suggestions for improvement based on the contents of the Issue."
         system_prompt: "The following is the GitHub Issue and comments on it. Please identify the issues that need to be resolved based on the contents of the Issue and provide three suggestions for improvement.\n"
+        require_intent: false
     - ask:
         description: "Answer free-text questions."
         system_prompt: "The following is the GitHub Issue and comments on it. Based on the content provide a detailed response to the following question:\n"
+        require_intent: true

--- a/.github/workflows/alert-menta.yaml
+++ b/.github/workflows/alert-menta.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Alert-Menta:
-    if: (startsWith(github.event.comment.body, '/describe') || startsWith(github.event.comment.body, '/suggest') || startsWith(github.event.comment.body, '/ask')) && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    if: startsWith(github.event.comment.body, '/') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-24.04
     permissions:
       issues: write
@@ -24,21 +24,6 @@ jobs:
           | jq '.assets[] | select(.name | contains("Linux_x86")) | .id')"
           tar -zxvf alert-menta_Linux_x86_64.tar.gz
 
-      - name: Set Command
-        id: set_command
-        run: |
-          COMMENT_BODY="${{ github.event.comment.body }}"
-          if [[ "$COMMENT_BODY" == /ask* ]]; then
-            COMMAND=ask
-            INTENT=${COMMENT_BODY:5}
-            echo "INTENT=$INTENT" >> $GITHUB_ENV
-          elif [[ "$COMMENT_BODY" == /describe* ]]; then
-            COMMAND=describe
-          elif [[ "$COMMENT_BODY" == /suggest* ]]; then
-            COMMAND=suggest
-          fi
-          echo "COMMAND=$COMMAND" >> $GITHUB_ENV
-
       - run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" >> $GITHUB_ENV
 
       - name: Get user defined config file
@@ -47,9 +32,27 @@ jobs:
         run: |
           curl -H "Authorization: token ${{ secrets.GH_TOKEN }}" -L -o .alert-menta.user.yaml "https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.REPOSITORY_NAME }}/main/.alert-menta.user.yaml" && echo "CONFIG_FILE=./.alert-menta.user.yaml" >> $GITHUB_ENV
 
+      - name: Extract command and intent
+        id: extract_command
+        run: |
+          COMMENT_BODY="${{ github.event.comment.body }}"
+          COMMAND=$(echo "$COMMENT_BODY" | sed -E 's|^/([^ ]*).*|\1|')
+          echo "COMMAND=$COMMAND" >> $GITHUB_ENV
+          
+          if [[ "$COMMENT_BODY" == "/$COMMAND "* ]]; then
+            INTENT=$(echo "$COMMENT_BODY" | sed -E "s|^/$COMMAND ||")
+            echo "INTENT=$INTENT" >> $GITHUB_ENV
+          fi
+          
+          COMMANDS_CHECK=$(yq e '.ai.commands[] | keys' .alert-menta.user.yaml | grep -c "$COMMAND" || echo "0")
+          if [ "$COMMANDS_CHECK" -eq "0" ]; then
+            echo "Invalid command: $COMMAND. Command not found in configuration."
+            exit 1
+          fi
+
       - name: Add Comment
         run: |
-          if [[ "$COMMAND" == "ask" ]]; then
+          if [ -n "$INTENT" ]; then
             ./alert-menta -owner ${{ github.repository_owner }} -issue ${{ github.event.issue.number }} -repo ${{ env.REPOSITORY_NAME }} -github-token ${{ secrets.GH_TOKEN }} -api-key ${{ secrets.OPENAI_API_KEY }} -command $COMMAND -config $CONFIG_FILE -intent "$INTENT"
           else
             ./alert-menta -owner ${{ github.repository_owner }} -issue ${{ github.event.issue.number }} -repo ${{ env.REPOSITORY_NAME }} -github-token ${{ secrets.GH_TOKEN }} -api-key ${{ secrets.OPENAI_API_KEY }} -command $COMMAND -config $CONFIG_FILE

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,47 @@ func main() {
 
 	issue := github.NewIssue(cfg.owner, cfg.repo, cfg.issueNumber, cfg.ghToken)
 
+	// Validate command
+	err = validateCommand(cfg.command, loadedcfg)
+	if err != nil {
+		// Get available commands for the error message
+		availableCommands := getAvailableCommands(loadedcfg)
+		usageMessage := fmt.Sprintf("**Error**: %v\n\n**Available commands:**\n", err)
+
+		// Add each command with its description to the usage message
+		for cmd, description := range availableCommands {
+			usageMessage += fmt.Sprintf("- `/%s`: %s\n", cmd, description)
+		}
+
+		// Post the usage message as a comment
+		if postErr := issue.PostComment(usageMessage); postErr != nil {
+			logger.Fatalf("Error posting error comment: %v", postErr)
+		}
+
+		// Exit with error code
+		logger.Printf("Error validating command: %v", err)
+		os.Exit(1)
+	}
+
+	// Check if intent is required for this command and missing
+	needsIntent, err := commandNeedsIntent(cfg.command, loadedcfg)
+	if err != nil {
+		logger.Fatalf("Error checking if intent is required: %v", err)
+	}
+	if needsIntent && cfg.intent == "" {
+		usageMessage := fmt.Sprintf("**Error**: The `/%s` command requires additional text after the command.\n\n**Usage**: `/%s [your text here]`",
+			cfg.command, cfg.command)
+
+		// Post the usage message as a comment
+		if postErr := issue.PostComment(usageMessage); postErr != nil {
+			logger.Fatalf("Error posting error comment: %v", postErr)
+		}
+
+		// Exit with error code
+		logger.Printf("Error: intent required for command %s", cfg.command)
+		os.Exit(1)
+	}
+
 	userPrompt, imgs, err := constructUserPrompt(cfg.ghToken, issue, loadedcfg, logger)
 	if err != nil {
 		logger.Fatalf("Erro constructing userPrompt: %v", err)
@@ -95,6 +136,27 @@ func validateCommand(command string, cfg *utils.Config) error {
 		return fmt.Errorf("Invalid command: %s. Allowed commands are %s", command, strings.Join(allowedCommands, ", "))
 	}
 	return nil
+}
+
+// Check if a command requires an intent
+func commandNeedsIntent(command string, cfg *utils.Config) (bool, error) {
+	// Get the command configuration
+	cmd, ok := cfg.Ai.Commands[command]
+	if !ok {
+		return false, fmt.Errorf("Command not found: %s", command)
+	}
+
+	// Check if this command requires intent
+	return cmd.Require_intent, nil
+}
+
+// Get available commands with descriptions for usage message
+func getAvailableCommands(cfg *utils.Config) map[string]string {
+	commands := make(map[string]string)
+	for cmd, cmdConfig := range cfg.Ai.Commands {
+		commands[cmd] = cmdConfig.Description
+	}
+	return commands
 }
 
 // Construct user prompt from issue
@@ -147,9 +209,9 @@ func constructUserPrompt(ghToken string, issue *github.GitHubIssue, cfg *utils.C
 // Construct AI prompt
 func constructPrompt(command, intent, userPrompt string, imgs []ai.Image, cfg *utils.Config, logger *log.Logger) (*ai.Prompt, error) {
 	var systemPrompt string
-	if command == "ask" {
+	if cfg.Ai.Commands[command].Require_intent {
 		if intent == "" {
-			return nil, fmt.Errorf("Error: intent is required for 'ask' command")
+			return nil, fmt.Errorf("Error: intent is required for '%s' command", command)
 		}
 		systemPrompt = cfg.Ai.Commands[command].System_prompt + intent + "\n"
 	} else {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -36,8 +36,9 @@ type Ai struct {
 }
 
 type Command struct {
-	Description   string `yaml:"description"`
-	System_prompt string `yaml:"system_prompt"`
+	Description    string `yaml:"description"`
+	System_prompt  string `yaml:"system_prompt"`
+	Require_intent bool   `yaml:"require_intent"`
 }
 
 type OpenAI struct {


### PR DESCRIPTION
## Overview
ユーザ定義のコマンドをシームレスに実行できるようにした。
現在の Alert-Menta の構成では、.alert-menta.user.yaml にカスタムコマンドを定義した場合、それに合わせて alert-menta.yaml のワークフローにも変更を加える必要があった。
また、カスタムコマンドにユーザによる入力（intent）を加えることは出来なかった。

## Cause and remedy (in the case of bug fixes) 
## What i did
- alert-menta.yaml のカスタムコマンドへの対応
  - 現在は、alert-menta.yaml 中に/ask等の事前定義コマンドがコメントされたときにトリガーするような設定が記載されている
  - カスタムコマンドを定義した際にはここにカスタムコマンドを追加する必要があった
- .alert-menta.user.yaml に require-intent フィールドを追加
  - intent の有無を指定できる
- コマンドの指定、intent の指定についてバリデーションを行い、不正な場合は Usage をコメントに出力する
![image](https://github.com/user-attachments/assets/87268524-c3a2-4963-987e-e5d93f25ce76)
![image](https://github.com/user-attachments/assets/aba1b2b8-120c-4040-a8d9-9e8951c95612)
## Change Result
特になし
## Content outside the scope of this PR
- README の変更は行っていない
## Precautions (What to let members know)
- alert-menta.yaml と.alert-menta.user.yaml に変更を加えているため、Actions 上での動作を確認する必要がある
- yaml に項目を追加しているためそれに合わせて main_test.go を修正する必要がある。（本 PR にてテストを提出）
- 本 PR に合わせて README の変更が必要となる。
## Usage and procedures after the change
- .alert-menta.user.yaml に require_intent というフィールドを追加する
## Especially where you want us to review
特になし 
## notes
特になし

