### PR TITLE
Issue の Body の画像取得

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/3-shake/alert-menta/internal/ai"
@@ -99,6 +98,8 @@ func validateCommand(command string, cfg *utils.Config) error {
 
 // Construct user prompt from issue
 func constructUserPrompt(ghToken string, issue *github.GitHubIssue, cfg *utils.Config, logger *log.Logger) (string, []ai.Image, error) {
+	var images []ai.Image
+
 	title, err := issue.GetTitle()
 	if err != nil {
 		return "", nil, fmt.Errorf("Error getting Title: %w", err)
@@ -112,14 +113,19 @@ func constructUserPrompt(ghToken string, issue *github.GitHubIssue, cfg *utils.C
 	var userPrompt strings.Builder
 	userPrompt.WriteString("Title:" + *title + "\n")
 	userPrompt.WriteString("Body:" + *body + "\n")
+	urls := utils.ExtractImageURLs(*body)
+	for _, url := range urls {
+		imgData, ext, err := utils.DownloadImage(url, ghToken)
+		if err != nil {
+			return "", nil, fmt.Errorf("Error downloading image: %w", err)
+		}
+		images = append(images, ai.Image{Data: imgData, Extension: ext})
+	}
 
 	comments, err := issue.GetComments()
 	if err != nil {
 		return "", nil, fmt.Errorf("Error getting comments: %w", err)
 	}
-
-	var images []ai.Image
-	imageRegex := regexp.MustCompile(`!\[(.*?)\]\((.*?)\)`)
 
 	for _, v := range comments {
 		if *v.User.Login == "github-actions[bot]" {
@@ -130,14 +136,12 @@ func constructUserPrompt(ghToken string, issue *github.GitHubIssue, cfg *utils.C
 		}
 		userPrompt.WriteString(*v.User.Login + ":" + *v.Body + "\n")
 
-		matches := imageRegex.FindAllStringSubmatch(*v.Body, -1)
-		for _, match := range matches {
-			logger.Println("Image URL:", match[2]) // Log the URL of the image
-			imgData, ext, err := utils.DownloadImage(match[2], ghToken)
+		urls := utils.ExtractImageURLs(*body)
+		for _, url := range urls {
+			imgData, ext, err := utils.DownloadImage(url, ghToken)
 			if err != nil {
 				return "", nil, fmt.Errorf("Error downloading image: %w", err)
 			}
-
 			images = append(images, ai.Image{Data: imgData, Extension: ext})
 		}
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -139,3 +139,13 @@ func ImageToBase64(data []byte, ext string) string {
 	base64img := base64.StdEncoding.EncodeToString(data)
 	return "data:image/" + ext + ";base64," + base64img
 }
+
+func ExtractImageURLs(body string) []string {
+	imageRegex := regexp.MustCompile(`!\[(.*?)\]\((.*?)\)`)
+	matches := imageRegex.FindAllStringSubmatch(body, -1)
+	var urls []string
+	for _, match := range matches {
+		urls = append(urls, match[2])
+	}
+	return urls
+}


### PR DESCRIPTION
## Overview 
Issue のボディ内の画像を取得できていなかったため修正を行った。
（Issue 内のコメントについては画像を取得できる）
## Cause and remedy (in the case of bug fixes) 
- Issue の Body は画像のリンクを抽出する対象外になっていた
## What i did
- Issue の Body 内の画像のリンクも取得する
- utils に画像のリンクを取得する関数（ExtractImageURLs）を追加
## Change Result
特になし
## Content outside the scope of this PR
- ExtractImageURLs のテストコードは記述していない
## Precautions (What to let members know)
特になし
## Usage and procedures after the change
特になし
## Especially where you want us to review
特になし
## notes
