### PR TITLE
feat(notifications): add Slack notification integration

### DIFF
--- a/.alert-menta.user.yaml
+++ b/.alert-menta.user.yaml
@@ -1,5 +1,5 @@
 system:
-  debug: 
+  debug:
     log_level: debug
 
 ai:
@@ -11,7 +11,7 @@ ai:
     project: "<YOUR_PROJECT_ID>"
     location: "us-central1"
     model: "gemini-2.0-flash-001"
-  
+
   commands:
     - describe:
         description: "Generate a detailed description of the Issue."
@@ -143,3 +143,13 @@ ai:
           ---
           The following is the GitHub Issue and comments representing the incident timeline:
         require_intent: false
+
+# Slack notification settings
+notifications:
+  slack:
+    enabled: false  # Set to true to enable Slack notifications
+    webhook_url: ""  # Your Slack Incoming Webhook URL (or use -slack-webhook-url flag)
+    channel: ""  # Optional: Override webhook default channel (e.g., "#incidents")
+    notify_on:
+      - command_response  # Notify when AI responds to a command
+      # - incident_created  # Notify when new incident is created (future feature)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,42 @@ The built-in `postmortem` command generates comprehensive postmortem documentati
     require_intent: false
 ```
 
+### Slack Notifications
+alert-menta can send notifications to Slack when AI responds to commands. This is useful for keeping your team informed about incident analysis.
+
+#### Configuration
+Add the following to your `.alert-menta.user.yaml`:
+```yaml
+notifications:
+  slack:
+    enabled: true
+    webhook_url: "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
+    channel: "#incidents"  # Optional: Override webhook default channel
+    notify_on:
+      - command_response  # Notify when AI responds to a command
+```
+
+#### Using CLI Flag
+You can also pass the webhook URL as a command-line flag:
+```bash
+./alert-menta -slack-webhook-url "https://hooks.slack.com/services/YOUR/WEBHOOK/URL" ...
+```
+The CLI flag takes precedence over the config file setting.
+
+#### Setup Slack Webhook
+1. Go to your Slack workspace settings
+2. Navigate to "Apps" > "Incoming Webhooks"
+3. Create a new webhook and select the channel
+4. Copy the webhook URL to your config or secrets
+
+#### GitHub Actions Integration
+Add your Slack webhook URL to GitHub Secrets and update your workflow:
+```yaml
+- name: Add Comment
+  run: |
+    ./alert-menta ... -slack-webhook-url ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
 ### Actions
 #### Template
 The `.github/workflows/alert-menta.yaml` in this repository is a template. The contents are as follows:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,19 +9,21 @@ import (
 
 	"github.com/3-shake/alert-menta/internal/ai"
 	"github.com/3-shake/alert-menta/internal/github"
+	"github.com/3-shake/alert-menta/internal/slack"
 	"github.com/3-shake/alert-menta/internal/utils"
 )
 
-// Struct to hold the command-line arguments
+// Config holds command-line arguments
 type Config struct {
-	repo        string
-	owner       string
-	issueNumber int
-	intent      string
-	command     string
-	configFile  string
-	ghToken     string
-	oaiKey      string
+	repo            string
+	owner           string
+	issueNumber     int
+	intent          string
+	command         string
+	configFile      string
+	ghToken         string
+	oaiKey          string
+	slackWebhookURL string
 }
 
 func main() {
@@ -34,6 +36,7 @@ func main() {
 	flag.StringVar(&cfg.configFile, "config", "", "Configuration file")
 	flag.StringVar(&cfg.ghToken, "github-token", "", "GitHub token")
 	flag.StringVar(&cfg.oaiKey, "api-key", "", "OpenAI api key")
+	flag.StringVar(&cfg.slackWebhookURL, "slack-webhook-url", "", "Slack webhook URL for notifications (optional)")
 	flag.Parse()
 
 	if cfg.repo == "" || cfg.owner == "" || cfg.issueNumber == 0 || cfg.ghToken == "" || cfg.command == "" || cfg.configFile == "" {
@@ -117,6 +120,11 @@ func main() {
 
 	if err := issue.PostComment(comment); err != nil {
 		logger.Fatalf("Error creating comment: %v", err)
+	}
+
+	// Send Slack notification if configured
+	if err := sendSlackNotification(cfg, loadedcfg, issue, comment, logger); err != nil {
+		logger.Printf("Warning: failed to send Slack notification: %v", err)
 	}
 }
 
@@ -241,4 +249,54 @@ func getAIClient(oaiKey string, cfg *utils.Config, logger *log.Logger) (ai.Ai, e
 	default:
 		return nil, fmt.Errorf("invalid provider: %s", cfg.Ai.Provider)
 	}
+}
+
+// sendSlackNotification sends a notification to Slack if configured
+func sendSlackNotification(cfg *Config, loadedcfg *utils.Config, issue *github.GitHubIssue, response string, logger *log.Logger) error {
+	// Determine webhook URL (CLI flag takes precedence over config)
+	webhookURL := cfg.slackWebhookURL
+	if webhookURL == "" && loadedcfg.Notifications.Slack.Enabled {
+		webhookURL = loadedcfg.Notifications.Slack.WebhookURL
+	}
+
+	// No Slack notification configured
+	if webhookURL == "" {
+		return nil
+	}
+
+	// Check if command_response notification is enabled
+	if loadedcfg.Notifications.Slack.Enabled {
+		notifyOn := loadedcfg.Notifications.Slack.NotifyOn
+		if len(notifyOn) > 0 && !contains(notifyOn, "command_response") {
+			logger.Println("Slack notification skipped: command_response not in notify_on list")
+			return nil
+		}
+	}
+
+	// Get issue details for notification
+	title, err := issue.GetTitle()
+	if err != nil {
+		return fmt.Errorf("getting issue title for Slack: %w", err)
+	}
+
+	issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", cfg.owner, cfg.repo, cfg.issueNumber)
+
+	// Create Slack client and send notification
+	slackClient := slack.NewClient(webhookURL, loadedcfg.Notifications.Slack.Channel)
+	if err := slackClient.SendCommandResponse(*title, issueURL, cfg.command, response); err != nil {
+		return fmt.Errorf("sending Slack notification: %w", err)
+	}
+
+	logger.Println("Slack notification sent successfully")
+	return nil
+}
+
+// contains checks if a string slice contains a specific string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -1,0 +1,131 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Client handles Slack webhook notifications
+type Client struct {
+	WebhookURL string
+	Channel    string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a new Slack client
+func NewClient(webhookURL, channel string) *Client {
+	return &Client{
+		WebhookURL: webhookURL,
+		Channel:    channel,
+		HTTPClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Message represents a Slack message
+type Message struct {
+	Channel     string       `json:"channel,omitempty"`
+	Text        string       `json:"text"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+}
+
+// Attachment represents a Slack message attachment
+type Attachment struct {
+	Color     string   `json:"color"`
+	Title     string   `json:"title,omitempty"`
+	TitleLink string   `json:"title_link,omitempty"`
+	Text      string   `json:"text"`
+	Footer    string   `json:"footer,omitempty"`
+	Fields    []Field  `json:"fields,omitempty"`
+	MrkdwnIn  []string `json:"mrkdwn_in,omitempty"`
+}
+
+// Field represents a field in a Slack attachment
+type Field struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short"`
+}
+
+// SendCommandResponse sends a notification about a command execution result
+func (c *Client) SendCommandResponse(issueTitle, issueURL, command, response string) error {
+	// Truncate response if too long for Slack
+	maxLen := 2000
+	displayResponse := response
+	if len(response) > maxLen {
+		displayResponse = response[:maxLen] + "\n\n... (truncated, see full response in GitHub Issue)"
+	}
+
+	msg := Message{
+		Text: fmt.Sprintf("🤖 alert-menta `/%s` command executed", command),
+		Attachments: []Attachment{
+			{
+				Color:     "#36a64f",
+				Title:     issueTitle,
+				TitleLink: issueURL,
+				Text:      displayResponse,
+				Footer:    "alert-menta | GitHub Issue",
+				MrkdwnIn:  []string{"text"},
+			},
+		},
+	}
+
+	if c.Channel != "" {
+		msg.Channel = c.Channel
+	}
+
+	return c.send(msg)
+}
+
+// SendIncidentNotification sends a notification about a new incident
+func (c *Client) SendIncidentNotification(issueTitle, issueURL, summary string) error {
+	msg := Message{
+		Text: "🚨 New Incident Created",
+		Attachments: []Attachment{
+			{
+				Color:     "danger",
+				Title:     issueTitle,
+				TitleLink: issueURL,
+				Text:      summary,
+				Footer:    "alert-menta",
+				MrkdwnIn:  []string{"text"},
+			},
+		},
+	}
+
+	if c.Channel != "" {
+		msg.Channel = c.Channel
+	}
+
+	return c.send(msg)
+}
+
+// send sends a message to Slack via webhook
+func (c *Client) send(msg Message) error {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.WebhookURL, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("slack webhook returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -1,0 +1,143 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	client := NewClient("https://hooks.slack.com/test", "#incidents")
+
+	if client.WebhookURL != "https://hooks.slack.com/test" {
+		t.Errorf("expected webhook URL to be set")
+	}
+	if client.Channel != "#incidents" {
+		t.Errorf("expected channel to be #incidents")
+	}
+	if client.HTTPClient == nil {
+		t.Errorf("expected HTTP client to be initialized")
+	}
+}
+
+func TestSendCommandResponse(t *testing.T) {
+	var receivedMessage Message
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json")
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&receivedMessage); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "#test-channel")
+	err := client.SendCommandResponse(
+		"Test Issue",
+		"https://github.com/test/repo/issues/1",
+		"describe",
+		"This is a test response",
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMessage.Channel != "#test-channel" {
+		t.Errorf("expected channel #test-channel, got %s", receivedMessage.Channel)
+	}
+	if len(receivedMessage.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(receivedMessage.Attachments))
+	}
+	if receivedMessage.Attachments[0].Title != "Test Issue" {
+		t.Errorf("expected title 'Test Issue', got %s", receivedMessage.Attachments[0].Title)
+	}
+}
+
+func TestSendIncidentNotification(t *testing.T) {
+	var receivedMessage Message
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedMessage); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "")
+	err := client.SendIncidentNotification(
+		"Production Outage",
+		"https://github.com/test/repo/issues/2",
+		"API server is down",
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMessage.Text != "🚨 New Incident Created" {
+		t.Errorf("unexpected message text: %s", receivedMessage.Text)
+	}
+	if receivedMessage.Attachments[0].Color != "danger" {
+		t.Errorf("expected danger color for incident")
+	}
+}
+
+func TestSendCommandResponse_TruncatesLongResponse(t *testing.T) {
+	var receivedMessage Message
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedMessage); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "")
+
+	// Create a very long response
+	longResponse := ""
+	for i := 0; i < 300; i++ {
+		longResponse += "This is a long response line. "
+	}
+
+	err := client.SendCommandResponse(
+		"Test Issue",
+		"https://github.com/test/repo/issues/1",
+		"describe",
+		longResponse,
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(receivedMessage.Attachments[0].Text) > 2100 {
+		t.Errorf("response was not truncated properly")
+	}
+}
+
+func TestSend_ErrorOnNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "")
+	err := client.SendCommandResponse("Test", "http://test", "describe", "test")
+
+	if err == nil {
+		t.Errorf("expected error for non-200 response")
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -16,8 +16,22 @@ import (
 
 // Root structure of information read from config file
 type Config struct {
-	System System `yaml:"system"`
-	Ai     Ai     `yaml:"ai"`
+	System        System        `yaml:"system"`
+	Ai            Ai            `yaml:"ai"`
+	Notifications Notifications `yaml:"notifications"`
+}
+
+// Notifications holds notification configuration
+type Notifications struct {
+	Slack SlackConfig `yaml:"slack"`
+}
+
+// SlackConfig holds Slack notification settings
+type SlackConfig struct {
+	Enabled    bool     `yaml:"enabled"`
+	WebhookURL string   `yaml:"webhook_url" mapstructure:"webhook_url"`
+	Channel    string   `yaml:"channel"`
+	NotifyOn   []string `yaml:"notify_on" mapstructure:"notify_on"`
 }
 
 type System struct {


### PR DESCRIPTION
## Summary
- Add Slack webhook notification support for alert-menta (#54)
- Notifications can be sent when AI responds to commands
- Configurable via `.alert-menta.user.yaml` or CLI flag

## Changes
- New `internal/slack/` package with webhook client
- Updated `cmd/main.go` with Slack notification integration
- Added `notifications` config section to `internal/utils/utils.go`
- Updated documentation in `README.md`
- Fixed golangci-lint v2 config (added `version: "2"` and `formatters` section)

## Configuration Example
```yaml
notifications:
  slack:
    enabled: true
    webhook_url: "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
    channel: "#incidents"
    notify_on:
      - command_response
```

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Unit tests pass: `go test ./...`
- [ ] Lint passes: `golangci-lint run`
- [ ] Slack notification sends when webhook URL is configured
- [ ] CLI flag `-slack-webhook-url` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)