### PR TITLE
feat(ai): add structured output support

### DIFF
--- a/.alert-menta.user.yaml
+++ b/.alert-menta.user.yaml
@@ -308,6 +308,48 @@ ai:
           ---
           The following is the GitHub Issue and comments. Generate the incident timeline:
         require_intent: false
+    # Example command with structured output (#64)
+    - triage:
+        description: "Automatically triage the incident with structured JSON output."
+        system_prompt: |
+          You are an SRE expert. Analyze the incident and provide a structured triage assessment.
+          Return ONLY a valid JSON object with the specified schema.
+        require_intent: false
+        structured_output:
+          enabled: true
+          schema_name: "incident_triage"
+          schema:
+            type: object
+            properties:
+              severity:
+                type: string
+                enum: ["critical", "high", "medium", "low"]
+                description: "Incident severity level"
+              category:
+                type: string
+                enum: ["infrastructure", "application", "database", "network", "security", "other"]
+                description: "Incident category"
+              summary:
+                type: string
+                description: "Brief summary of the incident"
+              affected_services:
+                type: array
+                items:
+                  type: string
+                description: "List of affected services"
+              recommended_actions:
+                type: array
+                items:
+                  type: string
+                description: "Recommended immediate actions"
+              estimated_impact:
+                type: string
+                description: "Estimated user/business impact"
+            required:
+              - severity
+              - category
+              - summary
+          fallback_to_text: true
 
 # First Response Guide settings (#62)
 # Automatically posts an incident response guide when issues with specific labels are created

--- a/README.md
+++ b/README.md
@@ -186,6 +186,50 @@ When fallback is enabled, the primary `ai.provider` setting is ignored, and prov
 - `anthropic` - Anthropic API (Claude)
 - `vertexai` - Google Vertex AI (Gemini)
 
+### Structured Output
+alert-menta supports structured JSON output for commands that need machine-parseable responses. This is useful for integrations with other systems.
+
+#### Configuration
+Add `structured_output` to any command in your `.alert-menta.user.yaml`:
+```yaml
+commands:
+  - triage:
+      description: "Triage incident with structured output"
+      system_prompt: "Analyze the incident..."
+      require_intent: false
+      structured_output:
+        enabled: true
+        schema_name: "incident_triage"
+        schema:
+          type: object
+          properties:
+            severity:
+              type: string
+              enum: ["critical", "high", "medium", "low"]
+            category:
+              type: string
+            summary:
+              type: string
+          required: ["severity", "category", "summary"]
+        fallback_to_text: true
+```
+
+#### Output Example
+```json
+{
+  "severity": "high",
+  "category": "infrastructure",
+  "summary": "API server returning 500 errors due to database connection issues"
+}
+```
+
+#### Provider Support
+| Provider | JSON Mode | Schema Validation |
+|----------|-----------|-------------------|
+| OpenAI | Yes | Yes (native) |
+| Anthropic | Yes | Via prompt |
+| VertexAI | Yes | Via prompt |
+
 ### Slack Notifications
 alert-menta can send notifications to Slack when AI responds to commands. This is useful for keeping your team informed about incident analysis.
 

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -1,5 +1,7 @@
 package ai
 
+import "encoding/json"
+
 type Ai interface {
 	GetResponse(prompt *Prompt) (string, error)
 }
@@ -9,8 +11,24 @@ type Image struct {
 	Extension string
 }
 
+// StructuredOutputOptions holds options for structured output
+type StructuredOutputOptions struct {
+	Enabled    bool
+	SchemaName string
+	Schema     map[string]interface{}
+}
+
 type Prompt struct {
-	UserPrompt   string
-	SystemPrompt string
-	Images       []Image
+	UserPrompt       string
+	SystemPrompt     string
+	Images           []Image
+	StructuredOutput *StructuredOutputOptions
+}
+
+// GetSchemaJSON returns the schema as JSON bytes
+func (s *StructuredOutputOptions) GetSchemaJSON() (json.RawMessage, error) {
+	if s == nil || s.Schema == nil {
+		return nil, nil
+	}
+	return json.Marshal(s.Schema)
 }

--- a/internal/ai/vertexai.go
+++ b/internal/ai/vertexai.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -19,11 +20,26 @@ func (ai *VertexAI) GetResponse(prompt *Prompt) (string, error) {
 	// Temperature recommended by LLM
 	model.SetTemperature(0.5)
 
+	// Set JSON mode for structured output
+	if prompt.StructuredOutput != nil && prompt.StructuredOutput.Enabled {
+		model.ResponseMIMEType = "application/json"
+	}
+
 	integratedPrompt := []genai.Part{} // image + text prompt
 	for _, image := range prompt.Images {
 		integratedPrompt = append(integratedPrompt, genai.ImageData(image.Extension, image.Data))
 	}
-	integratedPrompt = append(integratedPrompt, genai.Text(prompt.SystemPrompt+prompt.UserPrompt))
+
+	// Modify prompt for structured output
+	systemPrompt := prompt.SystemPrompt
+	if prompt.StructuredOutput != nil && prompt.StructuredOutput.Enabled {
+		schemaJSON, err := prompt.StructuredOutput.GetSchemaJSON()
+		if err == nil && schemaJSON != nil {
+			systemPrompt += fmt.Sprintf("\n\nRespond with valid JSON that conforms to this schema:\n%s", string(schemaJSON))
+		}
+	}
+
+	integratedPrompt = append(integratedPrompt, genai.Text(systemPrompt+prompt.UserPrompt))
 
 	// Generate AI response
 	resp, err := model.GenerateContent(ai.context, integratedPrompt...)
@@ -31,7 +47,16 @@ func (ai *VertexAI) GetResponse(prompt *Prompt) (string, error) {
 		return "", fmt.Errorf("GenerateContent error: %w", err)
 	}
 
-	return getResponseText(resp), nil
+	response := getResponseText(resp)
+
+	// Validate JSON output if structured output is enabled
+	if prompt.StructuredOutput != nil && prompt.StructuredOutput.Enabled {
+		if !json.Valid([]byte(response)) {
+			return "", fmt.Errorf("structured output validation failed: response is not valid JSON")
+		}
+	}
+
+	return response, nil
 }
 
 func getResponseText(resp *genai.GenerateContentResponse) string {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -90,9 +90,18 @@ type RetryConfig struct {
 }
 
 type Command struct {
-	Description   string `yaml:"description"`
-	SystemPrompt  string `yaml:"system_prompt" mapstructure:"system_prompt"`
-	RequireIntent bool   `yaml:"require_intent" mapstructure:"require_intent"`
+	Description      string                  `yaml:"description"`
+	SystemPrompt     string                  `yaml:"system_prompt" mapstructure:"system_prompt"`
+	RequireIntent    bool                    `yaml:"require_intent" mapstructure:"require_intent"`
+	StructuredOutput *StructuredOutputConfig `yaml:"structured_output,omitempty" mapstructure:"structured_output"`
+}
+
+// StructuredOutputConfig holds structured output settings for a command
+type StructuredOutputConfig struct {
+	Enabled        bool                   `yaml:"enabled" mapstructure:"enabled"`
+	Schema         map[string]interface{} `yaml:"schema,omitempty" mapstructure:"schema"`
+	SchemaName     string                 `yaml:"schema_name,omitempty" mapstructure:"schema_name"`
+	FallbackToText bool                   `yaml:"fallback_to_text" mapstructure:"fallback_to_text"`
 }
 
 type OpenAI struct {


### PR DESCRIPTION
## Summary
Add JSON structured output support for commands that need machine-parseable responses.

- OpenAI: Native JSON mode via ResponseFormat
- Anthropic: Prompt engineering + JSON validation
- VertexAI: application/json MIME type + validation

## New Command
Added `triage` command as example with full JSON schema definition.

## Configuration
```yaml
commands:
  - triage:
      structured_output:
        enabled: true
        schema_name: "incident_triage"
        schema:
          type: object
          properties:
            severity:
              type: string
              enum: ["critical", "high", "medium", "low"]
```

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [x] Triage command returns valid JSON

Closes #64

:robot: Generated with [Claude Code](https://claude.com/claude-code)